### PR TITLE
fix: scheme missing in bare autolinks

### DIFF
--- a/docs/cms.md
+++ b/docs/cms.md
@@ -10,9 +10,9 @@ This page is currently a skeleton for documentation to be added as the work evol
 
 ## High-level summary
 
-Wagtail CMS will be used to make either entire pages or portions of pages (let's call them 'surfaces') content-editable on <www.mozilla.org>. It is not a free-for-all add-any-page-you-like approach, but rather a careful rollout of surfaces with appropriate guard rails that helps ensure the integrity, quality and security of <www.mozilla.org>.
+Wagtail CMS will be used to make either entire pages or portions of pages (let's call them 'surfaces') content-editable on [www.mozilla.org](https://www.mozilla.org). It is not a free-for-all add-any-page-you-like approach, but rather a careful rollout of surfaces with appropriate guard rails that helps ensure the integrity, quality and security of [www.mozilla.org](https://www.mozilla.org).
 
-Surfaces will be authored via a closed 'Editing' deployment and when those changes are published they will become visible on the main <www.mozilla.org> 'Web' deployment.
+Surfaces will be authored via a closed 'Editing' deployment and when those changes are published they will become visible on the main [www.mozilla.org](https://www.mozilla.org) 'Web' deployment.
 
 If you are new to Wagtail, it is recommended that you read the official docs and/or complete an online course to get a better understanding of how Wagtail works.
 

--- a/docs/coding.md
+++ b/docs/coding.md
@@ -691,7 +691,7 @@ class CanadaIsSpecialView(GeoTemplateView):
 
 ### Testing Geo Views
 
-For testing purposes while you're developing or on any deployment that is not accessed via the production domain (<www.mozilla.org>) you can append your URL with a `geo` query param (e.g. `/firefox/?geo=DE`) and that will take precedence over the country from the request header. Remember to use a valid [ISO country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) as param value.
+For testing purposes while you're developing or on any deployment that is not accessed via the production domain ([www.mozilla.org](https://www.mozilla.org)) you can append your URL with a `geo` query param (e.g. `/firefox/?geo=DE`) and that will take precedence over the country from the request header. Remember to use a valid [ISO country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) as param value.
 
 ### Other Geo Stuff
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -254,7 +254,7 @@ To make the server run, make sure your virtualenv is activated with `pyenv activ
 
 Wait for the server to start up and then browse to <http://localhost:8000>
 
-Congratulations, you should now have your own copy of <www.mozilla.org> running locally!
+Congratulations, you should now have your own copy of [www.mozilla.org](https://www.mozilla.org) running locally!
 
 ### Prod Mode
 

--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -129,7 +129,7 @@ redirectpatterns = [
 
 ## Testing redirects
 
-A suite of tests exists for redirects, which is intended as a reference of the redirects we expect to work on <www.mozilla.org>. This will become a base for implementing these redirects in the bedrock app and allow us to test them before release.
+A suite of tests exists for redirects, which is intended as a reference of the redirects we expect to work on [www.mozilla.org](https://www.mozilla.org). This will become a base for implementing these redirects in the bedrock app and allow us to test them before release.
 
 ### Installation
 
@@ -145,7 +145,7 @@ pip install -r requirements/dev.txt
 
 ### Running the tests
 
-If you wish to run the full set of tests, which requires a deployed instance of the site (e.g. <www.mozilla.org>) you can set the `--base-url` command line option:
+If you wish to run the full set of tests, which requires a deployed instance of the site (e.g. [www.mozilla.org](https://www.mozilla.org)) you can set the `--base-url` command line option:
 
 ``` bash
 pytest --base-url https://www.mozilla.org tests/redirects/


### PR DESCRIPTION
__Description:__

Some of the autolinks are not working because they're missing the scheme. See https://mozmeao.github.io/platform-docs/cms/#high-level-summary

The following doesn't autolink because it has no `http(s)://`:

```md
<www.mozilla.org>
```

Note that this would also work:

```md
<https://www.mozilla.org>
```

__Changes:__

* `<www.mozilla.org>` -> `[www.mozilla.org](https://www.mozilla.org)`