### PR TITLE
Remove unused render_macros front matter

### DIFF
--- a/docs/abtest.md
+++ b/docs/abtest.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 # A/B Testing {: #ab_testing }
 
 ## Nimbus experiments

--- a/docs/attribution/0001-analytics.md
+++ b/docs/attribution/0001-analytics.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 # Website Analytics {: #analytics }
 
 ## Google Analytics

--- a/docs/attribution/0004-mozilla-accounts.md
+++ b/docs/attribution/0004-mozilla-accounts.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 # Mozilla accounts attribution
 
 For products such as Mozilla VPN, Relay, and Monitor, we use Mozilla account as an authentication and subscription service. In addition to Google Analytics for basic conversion tracking, we attribute web page visits and clicks and through to actual subscriptions and installs by passing a specific allow-list of known query parameters through to the subscription platform. This is accomplished by adding referral data as parameters to sign up links on product landing pages.

--- a/docs/cms.md
+++ b/docs/cms.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 # CMS
 
 Bedrock and Springfield's CMSes are powered by [Wagtail CMS](https://wagtail.org/).

--- a/docs/coding.md
+++ b/docs/coding.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 # Developing on Bedrock or Springfield {: #coding }
 
 ## Managing Dependencies

--- a/docs/content-cards.md
+++ b/docs/content-cards.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 # Using External Content Cards Data {: #content-cards }
 
 The [www-admin repo](https://www-admin.readthedocs.io/) contains data files and images that are synced to bedrock and available for use on any page. The docs for updating said data is available via that repo, but this page will explain how to use the cards data once it's in the bedrock database.

--- a/docs/firefox-downloads/desktop-download-as-default.md
+++ b/docs/firefox-downloads/desktop-download-as-default.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 The stub installer is has been configured to serve a version of Firefox that will set itself as the default
 browser during installation if the stub attribution code includes the campaign value `SET_DEFAULT_BROWSER`.
 

--- a/docs/firefox-downloads/desktop-download-pages.md
+++ b/docs/firefox-downloads/desktop-download-pages.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 What we typically refer to as the "download page" is [https://www.firefox.com/en-US/](https://www.firefox.com/en-US/) the request for that url is handled by the [DownloadView](https://github.com/mozmeao/springfield/blob/5ea60084360e5b434d1a2fd5cd4e09fc0a180b94/springfield/firefox/views.py#L438) view and will respond with one of a few templates. One of those templates is highly flexible and is frequently served at other URLs as well.
 
 # By URL

--- a/docs/firefox-downloads/desktop-download-support.md
+++ b/docs/firefox-downloads/desktop-download-support.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 ## Windows
 
 For Windows, we generally only serve the 32bit stub installer. The reason for this is that the installer can figure out if the OS is 32bit or 64bit more accurately than User Agent strings can be relied upon for. The installer can then trigger the full download for the most appropriate binary. The only exception to this is for Firefox Beta. Here we serve links to the full installer and rely upon 32bit / 64 bit detection at the website level. The reason for this is that only the full installer offers the ability to change the installation path, as by default installing Firefox Beta would override the default location for the release installation of Firefox.

--- a/docs/firefox-downloads/download-buttons.md
+++ b/docs/firefox-downloads/download-buttons.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 To ensure that visitors to Firefox download pages get served the correct build and installer type for their operating system, we rely on [User Agent](https://developer.mozilla.org/docs/Glossary/User_agent) information to figure out what's needed. We primarily use the [Client Hints API](https://developer.mozilla.org/docs/Web/HTTP/Guides/Client_hints) to query this information, falling back to [navigator.UserAgent](https://developer.mozilla.org/docs/Web/API/Navigator/userAgent) for other web browsers.
 
 The logic for this User Agent detection can be found in `/media/js/base/site.js`. The script adds a computed platform based CSS class name such as `windows`, `osx`, `linux`, `android` or `ios` to the root `<html>` element of the DOM. This class is then used as a styling hook for displaying platform specific content, such as the correct download button to display. The CSS selectors that are specific to Firefox download buttons can be found in `media/css/protocol/components/_download-button.scss`, which are imported into the global site base stylesheet.

--- a/docs/l10n.md
+++ b/docs/l10n.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 # Localization {: #l10n }
 
 !!! both "Mind the path"

--- a/docs/legal-docs.md
+++ b/docs/legal-docs.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 !!! bedrock "Bedrock Only"
     Legal docs are specific to www.mozilla.org
 

--- a/docs/mozilla-accounts.md
+++ b/docs/mozilla-accounts.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 # Mozilla accounts helpers
 
 !!! note

--- a/docs/newsletters.md
+++ b/docs/newsletters.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 # Newsletters
 
 Bedrock includes support for signing up for and managing subscriptions and preferences for Mozilla newsletters. 

--- a/docs/pr-checklists.md
+++ b/docs/pr-checklists.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 # Firefox Download As Default {: #download-as-default }
 
 - check box displays if requirements are met

--- a/docs/send-to-device.md
+++ b/docs/send-to-device.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 # Send to Device Widget {: #sendtodevice }
 
 The *Send to Device* widget is a single form which facilitates the sending of a download link from a desktop browser to a mobile device. The form allows sending via email.

--- a/docs/vpn-subscriptions.md
+++ b/docs/vpn-subscriptions.md
@@ -1,7 +1,3 @@
----
-render_macros: true
----
-
 # Mozilla VPN Subscriptions {: #vpn_subscriptions }
 
 The [Mozilla VPN landing page](https://www.mozilla.org/en-US/products/vpn/) displays both pricing and currency information that is dependant on someone's physical location in the world (using geo-location). If someone is in the United States, they should see pricing in \$USD, and if someone is in Germany they should see pricing in Euros. The page is also available in multiple languages, which can be viewed independently of someone's physical location. So someone who lives in Switzerland, but is viewing the page in German, should still see pricing and currency displayed in Swiss Francs (CHF).


### PR DESCRIPTION
The macros plugin is not configured, so this front matter serves no purpose.