### PR TITLE
Fix db preflight example

### DIFF
--- a/docs/cms/setup.md
+++ b/docs/cms/setup.md
@@ -51,12 +51,12 @@ The DB export is generated twice a day and is put into the same public cloud buc
 
 The DB will contain a table that knows the relative paths of the images uploaded to the CMS, but not the actual images. Those are in a cloud storage bucket, and if you want your local machine to have them available after you download the DB that expects them to be present, you can run `python manage.py download_media_to_local` which will sync down any images you don't already have.
 
-By default, `make preflight` and `./bin/run-db-download.py` will download a database file based on `bedrock-dev` or `springfield-dev`. If you want to download from stage or prod, which are also available in sanitised form, you need to specify which environment you want by prefixing the command with `AWS_DB_S3_BUCKET=bedrock-db-stage`,  `AWS_DB_S3_BUCKET=bedrock-db-prod`.
-`AWS_DB_S3_BUCKET=springfield-db-stage` or  `AWS_DB_S3_BUCKET=springfield-db-prod`.
+By default, `make preflight` and `./bin/run-db-download.py` will download a database file based on `bedrock-dev` or `springfield-dev`. If you want to download from stage or prod, which are also available in sanitised form, you need to specify which environment you want by prefixing the command with `AWS_DB_S3_BUCKET=bedrock-db-stage` or `AWS_DB_S3_BUCKET=bedrock-db-prod` for Bedrock, and `AWS_DB_S3_BUCKET=springfield-db-stage` or  `AWS_DB_S3_BUCKET=springfield-db-prod` for Springfield, e.g.:
 
-e.g. `AWS_DB_S3_BUCKET=bedrock-db-stage make preflight`
-
-`python manage.py download_media_to_local --environment=stage`
+```
+AWS_DB_S3_BUCKET=bedrock-db-stage make preflight
+python manage.py download_media_to_local --environment=stage
+```
 
 ## Infrastructure notes
 

--- a/docs/operations/databases.md
+++ b/docs/operations/databases.md
@@ -31,10 +31,12 @@ Your local Bedrock or Springfield installation will just download the Bedrock De
 
 The DB will contain a table that knows the relative paths of the images uploaded to the CMS, but not the actual images. Those are in a cloud storage bucket. To get the images if you need them, see [this documentation](../cms/images.md#ive-downloaded-a-fresh-db-and-the-images-are-missing)
 
-By default, `make preflight` or `./bin/run-db-download.py` will download a database file based on Bedrock Dev or Springfield Dev. If you want to download data from Stage or Prod, which are also available in sanitised form, you need to specify which environment you want by prefixing the command with `AWS_DB_S3_BUCKET=bedrock-db-stage`,  `AWS_DB_S3_BUCKET=bedrock-db-prod`.
-`AWS_DB_S3_BUCKET=springfield-db-stage` or  `AWS_DB_S3_BUCKET=springfield-db-prod`.
+By default, `make preflight` or `./bin/run-db-download.py` will download a database file based on Bedrock Dev or Springfield Dev. If you want to download data from Stage or Prod, which are also available in sanitised form, you need to specify which environment you want by prefixing the command with `AWS_DB_S3_BUCKET=bedrock-db-stage` or `AWS_DB_S3_BUCKET=bedrock-db-prod` for Bedrock, and `AWS_DB_S3_BUCKET=springfield-db-stage` or  `AWS_DB_S3_BUCKET=springfield-db-prod` for Springfield, e.g.:
 
-e.g. `AWS_DB_S3_BUCKET=bedrock-db-stage make preflight python manage.py download_media_to_local --environment=stage`
+```
+AWS_DB_S3_BUCKET=bedrock-db-stage make preflight
+python manage.py download_media_to_local --environment=stage
+```
 
 ## Ensuring new data gets exported to sqlite
 


### PR DESCRIPTION
The example command:

> e.g. `AWS_DB_S3_BUCKET=bedrock-db-stage make preflight python manage.py download_media_to_local --environment=stage`

seemed to either miss `&&` or line break.

Seeing the other occurrence as two lines, I also went that way.

(Also fixed some wording/formatting around, and made the two instances the same.)