### PR TITLE
Fix dead links

### DIFF
--- a/docs/code-review/checklists/index.md
+++ b/docs/code-review/checklists/index.md
@@ -23,6 +23,6 @@ These checklists are `bedrock` & `springfield` specific and are not intended to 
 
 Automated checks will also be run by GitHub to check:
 
-- [Pre-commit checks have been run](../../getting-started/install/#pre-commit-hooks) (fluent, ruff, stylelint, etc.)
+- [Pre-commit checks have been run](../../getting-started/install.md#pre-commit-hooks) (fluent, ruff, stylelint, etc.)
 - JS unit tests pass
 - Python unit tests pass

--- a/docs/development/feature-switches.md
+++ b/docs/development/feature-switches.md
@@ -190,7 +190,7 @@ As noted above, we can't just wrap a route definition in a `urlpatterns` with a 
 
 ### Switches for a route with our `page()` helper
 
-The [`page()` helper](/platform-docs/development/views/#page-helper) gives us a quick way to render a HTML template at a particular route, with support for our l10n machinery. However, the helper doesn't currently allow use of switches.
+The [`page()` helper](views.md#page-helper) gives us a quick way to render a HTML template at a particular route, with support for our l10n machinery. However, the helper doesn't currently allow use of switches.
 
 You can pass a switch's name in as a parameter in order to enable the view/page if the switch is ON, else the route will 404
 

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -7,11 +7,10 @@ This section covers how to build features for Bedrock and Springfield.
 - **[Managing Dependencies](dependencies.md)** - Python and Node.js package management
 - **[Asset Bundling](assets.md)** - Webpack configuration and static assets
 - **[Writing JavaScript](javascript.md)** - ES5, ES6/Babel, and modern JS
-- **[Adding Pages](adding-pages.md)** - URL patterns for new pages
+- **[Writing Views](views.md)** - URL patterns, views, variation views, and geo-based rendering
 - **[Finding Templates](finding-templates.md)** - Locating templates by URL
-- **[Writing Views](views.md)** - Views, variation views, and geo-based rendering
 - **[Working with Images](images.md)** - Image optimization and helpers
-- **[Database Migrations](migrations.md)** - Safe migration practices
+- **[Database Migrations](../operations/migrations.md)** - Safe migration practices
 
 ## Standards & Tools
 

--- a/docs/development/views.md
+++ b/docs/development/views.md
@@ -45,7 +45,7 @@ The variable `latest_version` will be available in the template.
 
 ## Writing a Custom View
 
-You should rarely need to write a view. Most pages are static and you should use the `page` function documented in [Adding Pages](adding-pages.md).
+You should rarely need to write a view. Most pages are static and you should use the `page` function documented in the [Page() helper](#page-helper) section above.
 
 If you need to write a view and the page is translated or translatable then it should use the `l10n_utils.render()` function to render the template.
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -61,7 +61,7 @@ After that setup, whenever you try to make a commit, the 'hooks' will check/lint
 ## Docker Installation
 
 !!! note
-    This method assumes you have [Docker installed for your platform](https://www.docker.com/). If not please do that now or skip to the [Pyenv Installation](#pyenv-installation) section.
+    This method assumes you have [Docker installed for your platform](https://www.docker.com/). If not please do that now or skip to the [Pyenv Installation](#pyenv-direct-installation) section.
 
 This is the simplest way to get started developing. If you're on Linux or Mac (and possibly Windows 10 with the Linux subsystem) you can run a script that will pull our production and development docker images and start them:
 
@@ -115,7 +115,7 @@ If you make a change to `media/static-bundles.json`, you'll need to restart Dock
 
 This method installs Python, dependencies, and runs the application directly on your machine using [pyenv](https://github.com/pyenv/pyenv) to manage Python versions and [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) to isolate dependencies.
 
-These instructions assume you have pip and Node.js installed. If you don't have ``pip`` installed (you probably do) you can install it with the instructions in [the pip docs](https://pip.pypa.io/en/stable/installing/).
+These instructions assume you have pip and Node.js installed. If you don't have ``pip`` installed (you probably do) you can install it with the instructions in [the pip docs](https://pip.pypa.io/en/stable/installation/).
 
 The following assumes you are on MacOS, using `zsh` as your shell and [Homebrew](https://brew.sh/) as your package manager. If you are not, there are installation instructions for a variety of platforms and shells in the READMEs for the two pyenv projects.
 

--- a/docs/l10n/configuration.md
+++ b/docs/l10n/configuration.md
@@ -338,7 +338,7 @@ The root `.toml` files point to the ones in `/configs/` and are a 'gateway' thro
     There are two repos, to hold the translation files as part of the pipeline.
 
     - **A repo in where the files are sent to** for the L10N team's automation to pick up. ([bedrock](https://github.com/mozilla-l10n/www-l10n/) / [springfield](https://github.com/mozilla-l10n/www-firefox-l10n)).
-    - **An optional repo where files are post-processed following translation**. ([bedrock](https:/github.com/mozmeao/www-l10n/) / [springfield](https://github.com/mozmeao/www-firefox-l10n/))
+    - **An optional repo where files are post-processed following translation**. ([bedrock](https://github.com/mozmeao/www-l10n/) / [springfield](https://github.com/mozmeao/www-firefox-l10n/))
 
         !!! important
             **This repo is optional if not using Pontoon/community translations.** Why? If the translations are done by the community (via Pontoon), there is a possibility that not enough of the strings will be translated in order to render the content in the relevant locale. We run a CI task to determine whether a locale has enough translated strings to be considered 'active'. If we used a vendor entirely, we would expect all locales to be 100% translated.


### PR DESCRIPTION
Both links in `development/index.md` were broken after the reorganisation in PR #27:

* `adding-pages.md` was never created as a standalone file. Its content was folded into `views.md`. Replaced the link and deduplicated the duplicate Views entry.
* `migrations.md` moved to `operations/migrations.md`. Updated the path.
* Fixed a follow-on dead link inside `views.md` that also pointed to `adding-pages.md`.

Also fixed a broken external URL:

* Updated a broken pip docs URL in `getting-started/install.md` (`/installing/` → `/installation/`).