### PR TITLE
Bump publishing CI to Node 24 actions

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -23,10 +23,10 @@ jobs:
           python-version: 3.13
           cache: pip
       - id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - run: pip install -r requirements.txt
       - run: mkdocs build -d site
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: ./site
   deploy:
@@ -40,4 +40,4 @@ jobs:
     needs: build
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Deprecated versions forced to run in Node 24 env since June 2.